### PR TITLE
Improved substitution by using the sparql algebra.

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+	"name": "Node.js",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/javascript-node:1-22-bullseye",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [ 3000 ],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "npm install"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/package.json
+++ b/package.json
@@ -8,11 +8,13 @@
   "dependencies": {
     "@comunica/query-sparql": "~3.1.2",
     "@comunica/query-sparql-file": "~3.1.2",
+    "sparqlalgebrajs": "^4.3.8",
     "sparqljs": "~3.7.1",
     "n3": "~1.17.3",
     "express": "~4.19.2",
     "config": "~3.3.11",
     "axios": "~1.7.2",
+    "lodash": "~4.17.21",
     "chalk": "~5.3.0"
   }
 }

--- a/src/computationHandler.js
+++ b/src/computationHandler.js
@@ -1,0 +1,142 @@
+/* Copyright (C) 2024 Flanders Make - CodesignS */
+
+import sparqljs from 'sparqljs';
+import comunica from '@comunica/query-sparql';
+import { ActionContext } from '@comunica/core/lib/index.js';
+import { LoggerPretty } from '@comunica/logger-pretty';
+import engineDefault from '@comunica/query-sparql/engine-default.js';
+import N3 from 'n3';
+const { DataFactory } = N3;
+const { namedNode, literal, defaultGraph, quad } = DataFactory;
+import fs from 'fs';
+import path from 'path';
+import config from 'config';
+import { pathToFileURL } from 'url';
+import chalk from 'chalk';
+import Query from './query.js';
+import QueryEngine from './engine.js';
+import { RESTComputePredicate } from './predicate.js';
+
+/**
+ * This class can perform computations of predicates that occur in a userquery.
+ * It refuses to compute predicates that occur in complex path expressions.
+ * 
+ * Limitations:
+ * - Predicate values will be added to a local temporary repo.
+ *   If those predicates result in IRIs, no reasoning will be done on their result.
+ *   This could be surprising to the user.
+ */
+export default class ComputationHandler {
+    // The SPARQL parser for internal use only.
+    _parser;
+    _doLog = false;
+    _redirects = {};
+    _predicatesToCompute = {};
+
+    constructor() {
+        this._parser = new sparqljs.Parser();
+    }
+
+    async handle(q, context, predicatesToCompute) {
+        this._predicatesToCompute = predicatesToCompute;
+        let sources = context.sources;
+        // https://github.com/comunica/comunica/issues/1003, https://github.com/comunica/comunica/issues/1074
+        // work-around
+        // if (sources.length == 1 && authSources[sources[0].value])
+        // 	context.httpAuth = authSources[sources[0].value];
+        // moved auth to otfcFetch()
+        if (q.type() === 'SELECT') {
+            this.validate(q); // FIXME: this should become less restrictive.
+
+            // then compute predicates, if any
+            let [ computed, triples ] = await this.computePredicates(q, context);
+            if (computed.length) {
+                let store = new N3.Store(); // local memory store, or direct elsewhere
+                // context.sources = [ store ];
+                if (triples.length) {
+                    // let insert = 'INSERT DATA {\n';
+                    for (const t of triples) {
+                        const s = (t.s.termType)? t.s : literal(t.s), p = (t.p.termType)? t.p : literal(t.p), o = (t.o.termType)? t.o : literal(t.o);
+                        store.addQuad(s, p, o);
+                        // insert += t.s + ' ' + t.p + ' ' + t.o + '.';
+                    }
+                    // insert += '}';
+                    // console.log(insert);
+                    //await engine.queryVoid(insert, context);
+                }
+                let fx = async (qx) => {
+                    return await this.filterComputedSubjects(qx, { sources: [ store ] });
+                };
+                let qo = await q.federate(computed, fx);
+                if (qo) {
+                    console.log(chalk.blue.bold('Offloading\n---\n') + qo.toString() + chalk.blue.bold('\n---'));
+                    // await offloadTriples(qo, { sources: sources, fetch: otfcFetch }, store);
+                    // context.sources = sources;
+                    await this.offloadTriples(qo, context, store);
+                }
+                for (const sq of q.subqueries) {
+                    let qo = await sq.federate(computed, fx);
+                    if (qo) {
+                        console.log(chalk.blue.bold('Offloading\n---\n') + qo.toString() + chalk.blue.bold('\n---'));
+                        // context.sources = sources;
+                        await this.offloadTriples(qo, context, store);
+                    }				
+                }
+
+                context.sources = [ store ];
+            }
+        }
+        return [ q.toString(), context ];
+    }
+
+    validate(query) {
+		if (query.groups().length) {
+			// excluding a.o. subqueries
+			throw new Error('Validation failed: group patterns are not supported');
+		}
+		if (query.whereTriples().filter(t => t.predicate.type === 'path').length) {
+			// excluding property paths (after normalization)
+			throw new Error('Validation failed: property paths are not supported');
+		}
+	}
+
+    async filterComputedSubjects(q, context) {
+        const limit = 10000;
+        const engine = new comunica.QueryEngine();
+        const bindingsStream = await engine.queryBindings(q, context);
+        const bindings = await bindingsStream.toArray({ limit: limit });
+        return (bindings.length === limit)? null : bindings;
+    }
+
+    async offloadTriples(q, context, store) {
+        return new Promise(async (resolve) => {
+            const engine = new comunica.QueryEngine();
+            const quadStream = await engine.queryQuads(q, context);
+            let n = 0;
+            quadStream.on('end', () => { console.log(chalk.yellow.bold('Cached ' + n + ' triples')); resolve(); });
+            quadStream.on('data', quad => {
+                store.add(quad);
+                n++;
+            });
+        });
+    }
+
+    async computePredicates(query, context, store) {
+        let predicates = Object.keys(this._predicatesToCompute), computed = [], data = [];
+        let queries = [ query ].concat(query.subqueries);
+        for (const q of queries) {
+            for (const t of q.whereTriples()) {
+                const p = t.predicate.value;
+                if (predicates.includes(p)) {
+                    if (!this._predicatesToCompute[p]) throw new Error('No predicate compute function registered for ' + p);
+                    console.log(chalk.blue.bold('Resolving <' + p + '>'));
+                    let triples = await this._predicatesToCompute[p].compute(q, context, new QueryEngine());
+                    console.log(chalk.yellow.bold('Computed ' + triples.length + ' triple(s)'));
+                    computed.push(p);
+                    data = data.concat(triples);
+                }
+            }
+        }
+        return [ computed, data ];
+    }
+}

--- a/src/engine.js
+++ b/src/engine.js
@@ -1,24 +1,22 @@
 /* Copyright (C) 2022 Flanders Make - CodesignS */
 
-import sparqljs from 'sparqljs';
 import comunica from '@comunica/query-sparql';
-import { ActionContext } from '@comunica/core/lib/index.js';
-import { LoggerPretty } from '@comunica/logger-pretty';
 import engineDefault from '@comunica/query-sparql/engine-default.js';
 import N3 from 'n3';
 const { DataFactory } = N3;
-const { namedNode, literal, defaultGraph, quad } = DataFactory;
 import fs from 'fs';
 import path from 'path';
 import config from 'config';
 import { pathToFileURL } from 'url';
-import axios from 'axios';
+import axios from 'axios'; 
 import chalk from 'chalk';
 import Query from './query.js';
-import Predicate from './predicate.js';
+import SubstitutionHandler from './substitutionHandler.js';
+import ComputationHandler from './computationHandler.js';
 import { RESTComputePredicate } from './predicate.js';
 
-const predicatesToCompute = {}, predicatesToSubstitute = {};
+const predicatesToCompute = {};
+const predicatesToSubstitute = {};
 const authSources = {};
 const extensionFunctions = {}
 
@@ -26,12 +24,16 @@ const engine = new comunica.QueryEngine();
 const debug = config.get('otfc.debug');
 
 export default class QueryEngine extends comunica.QueryEngine {
+	_substitutionHandler;
+	_computationHandler;
 
 	constructor(engine = engineDefault()) {
-		// console.log(engineDefault().mediatorQueryResultSerialize);
 		let actors = engine.mediatorQueryResultSerialize.bus.actors.filter(a => a.name === 'urn:comunica:default:query-result-serialize/actors#sparql-json');
 		if (actors.length == 1) actors[0].emitMetadata = false; // avoid metadata being added to a sparql-results-json response
 		super(engine);
+
+		this._substitutionHandler = new SubstitutionHandler();
+		this._computationHandler = new ComputationHandler();
 
 		let sources = config.get('otfc.sources');
 		for (const s of sources) {
@@ -43,20 +45,49 @@ export default class QueryEngine extends comunica.QueryEngine {
 	// override to intercept queries sent to a SPARQL endpoint
 	async query(query, context) {
 		let q = new Query(query);
-	    console.log(chalk.blue.bold('Preprocessing\n---\n') + q.toString() + chalk.blue.bold('\n---'));
-		const [ pq, ctx ] = await preprocess(q, context);
-		console.log(chalk.blue.bold('Executing\n---\n') + pq + chalk.blue.bold('\n---'));
-		return super.query(pq, ctx);
+		let ctx = context;
+
+		ctx.extensionFunctions = extensionFunctions;
+        ctx.httpTimeout = 120_000;
+        ctx.fetch = otfcFetch;
+
+		if (Object.keys(predicatesToSubstitute).length > 0) {
+			console.log(chalk.blue.bold('Applying substitutions\n---\n') + q.toString() + chalk.blue.bold('\n---'));
+			q = new Query(this._substitutionHandler.handle(q.toString(), predicatesToSubstitute));
+		}
+
+		if (Object.keys(predicatesToCompute).length > 0) {
+			console.log(chalk.blue.bold('Applying computations\n---\n') + q.toString() + chalk.blue.bold('\n---'));
+			[ q, ctx ] = await this._computationHandler.handle(q, ctx, predicatesToCompute);
+		}
+
+		console.log(chalk.blue.bold('Executing\n---\n') + q + chalk.blue.bold('\n---'));
+		const result = super.query(q.toString(), ctx);
+		return result;
 	}
 
 	// execute a query with predicates to resolve and print the results on stdout
 	async run(query, context, callback) {
-		let q = (query instanceof Query)? query : new Query(query);
 		return new Promise(async resolve => {
-	    	// console.log(chalk.blue.bold('Preprocessing\n---\n') + q.toString() + chalk.blue.bold('\n---'));
-			const [ pq, ctx ] = await preprocess(q, context);
-			console.log(chalk.blue.bold('Executing\n---\n') + pq + chalk.blue.bold('\n---'));
-			const bindingsStream = await engine.queryBindings(pq, ctx);
+			let q = (query instanceof Query)? query : new Query(query);
+			let ctx = context;
+	
+			ctx.extensionFunctions = extensionFunctions;
+			ctx.httpTimeout = 120_000;
+			ctx.fetch = otfcFetch;
+	
+			if (Object.keys(predicatesToSubstitute).length > 0) {
+				console.log(chalk.blue.bold('Applying substitutions\n---\n') + q.toString() + chalk.blue.bold('\n---'));
+				q = new Query(this._substitutionHandler.handle(q.toString(), predicatesToSubstitute));
+			}
+	
+			if (Object.keys(predicatesToCompute).length > 0) {
+				console.log(chalk.blue.bold('Applying computations\n---\n') + q.toString() + chalk.blue.bold('\n---'));
+				[ q, ctx ] = await this._computationHandler.handle(q, ctx, predicatesToCompute, extensionFunctions);
+			}
+	
+			console.log(chalk.blue.bold('Executing\n---\n') + q + chalk.blue.bold('\n---'));
+			const bindingsStream = await engine.queryBindings(q.toString(), ctx);
 			// bindingsStream.on('error', (err) => console.log(err));
 			bindingsStream.on('end', resolve);
 			bindingsStream.on('data', bindings => {
@@ -84,116 +115,12 @@ export default class QueryEngine extends comunica.QueryEngine {
 		return meta();
 	}
 
-	async substitute(predicate, query) {
-		return addJSSubstitutePredicate(predicate, new Query(query));
-	}
-}
-
-async function preprocess(q, context) {
-	let sources = context.sources;
-	context.extensionFunctions = extensionFunctions;
-	context.httpTimeout = 120_000;
-	context.fetch = otfcFetch;
-	// https://github.com/comunica/comunica/issues/1003, https://github.com/comunica/comunica/issues/1074
-	// work-around
-	// if (sources.length == 1 && authSources[sources[0].value])
-	// 	context.httpAuth = authSources[sources[0].value];
-	// moved auth to otfcFetch()
-	if (q.type() === 'SELECT') {
-		// first substitute predicates, if any
-		substitutePredicates(q, context);
-		// then compute predicates, if any
-		let [ computed, triples ] = await computePredicates(q, context);
-		if (computed.length) {
-			let store = new N3.Store(); // local memory store, or direct elsewhere
-			// context.sources = [ store ];
-			if (triples.length) {
-				// let insert = 'INSERT DATA {\n';
-				for (const t of triples) {
-					const s = (t.s.termType)? t.s : literal(t.s), p = (t.p.termType)? t.p : literal(t.p), o = (t.o.termType)? t.o : literal(t.o);
-					store.addQuad(s, p, o);
-					// insert += t.s + ' ' + t.p + ' ' + t.o + '.';
-				}
-				// insert += '}';
-				// console.log(insert);
-				//await engine.queryVoid(insert, context);
-			}
-			let fx = async (qx) => {
-				return await filterComputedSubjects(qx, { sources: [ store ] });
-			};
-			let qo = await q.federate(computed, fx);
-			if (qo) {
-				console.log(chalk.blue.bold('Offloading\n---\n') + qo.toString() + chalk.blue.bold('\n---'));
-				// await offloadTriples(qo, { sources: sources, fetch: otfcFetch }, store);
-				// context.sources = sources;
-				await offloadTriples(qo, context, store);
-			}
-			for (const sq of q.subqueries) {
-				let qo = await sq.federate(computed, fx);
-				if (qo) {
-					console.log(chalk.blue.bold('Offloading\n---\n') + qo.toString() + chalk.blue.bold('\n---'));
-					// context.sources = sources;
-					await offloadTriples(qo, context, store);
-				}				
-			}
-
-			context.sources = [ store ];
+	async addSubstitutePredicate(predicate, query) {
+		console.log('Added substitute query for predicate <' + predicate + '>');
+		predicatesToSubstitute[predicate] = {
+			substitutionQuery: query
 		}
 	}
-	return [ q.toString(), context ];
-}
-
-async function filterComputedSubjects(q, context) {
-	const limit = 10000;
-	const engine = new comunica.QueryEngine();
-	const bindingsStream = await engine.queryBindings(q, context);
-	const bindings = await bindingsStream.toArray({ limit: limit });
-	return (bindings.length === limit)? null : bindings;
-}
-
-async function offloadTriples(q, context, store) {
-	return new Promise(async (resolve) => {
-		const engine = new comunica.QueryEngine();
-		const quadStream = await engine.queryQuads(q, context);
-		let n = 0;
-		quadStream.on('end', () => { console.log(chalk.yellow.bold('Cached ' + n + ' triples')); resolve(); });
-		quadStream.on('data', quad => {
-			store.add(quad);
-			n++;
-		});
-	});
-}
-
-function substitutePredicates(q, context) {
-	let predicates = Object.keys(predicatesToSubstitute);
-	for (const t of q.whereTriples()) {
-		const p = t.predicate.value;
-		if (predicates.includes(p)) {
-			if (!predicatesToSubstitute[p]) throw new Error('No predicate substitute function registered for ' + p);
-			console.log(chalk.blue.bold('Resolving <' + p + '>'));
-			predicatesToSubstitute[p].substitute(q, context);
-			console.log(chalk.blue.bold('Substituted'));
-		}
-	}
-}
-
-async function computePredicates(query, context, store) {
-	let predicates = Object.keys(predicatesToCompute), computed = [], data = [];
-	let queries = [ query ].concat(query.subqueries);
-	for (const q of queries) {
-		for (const t of q.whereTriples()) {
-			const p = t.predicate.value;
-			if (predicates.includes(p)) {
-				if (!predicatesToCompute[p]) throw new Error('No predicate compute function registered for ' + p);
-				console.log(chalk.blue.bold('Resolving <' + p + '>'));
-				let triples = await predicatesToCompute[p].compute(q, context, new QueryEngine());
-				console.log(chalk.yellow.bold('Computed ' + triples.length + ' triple(s)'));
-				computed.push(p);
-				data = data.concat(triples);
-			}
-		}
-	}
-	return [ computed, data ];
 }
 
 async function loadPredicates() {
@@ -213,8 +140,8 @@ async function loadJSPredicates() {
 				}
 				try {
 					let mod = await import(pathToFileURL(path.join(p, f)));
-					if (mod.default.hasOwnProperty('substitute')) {
-						predicatesToSubstitute[mod.default.iri] = mod.default;
+					if (mod.default.hasOwnProperty('substitutionQuery')) {
+						predicatesToSubstitute[mod.default.iri] = mod.default.substitutionQuery;
 						console.log('Loaded substitute predicate plugin for <' + mod.default.iri + '>');
 					}
 					else if (mod.default.hasOwnProperty('compute')) {
@@ -274,64 +201,8 @@ async function loadPythonPredicates() {
 	}
 }
 
-function addJSSubstitutePredicate(predicate, query) {
-	console.log('Added substitute query for predicate <' + predicate + '>');
-	predicatesToSubstitute[predicate] = {
-		substitute: (q, context) => {
-			Predicate.submerge(q, query, predicate);
-		}
-	}
-}
-
 async function loadExtensionFunctions() {
 	// TODO: dynamically load from file similar to predicates
-}
-
-let redirects = {};
-
-function otfcFetch(input, options) {
-	let url = redirects[input]? redirects[input] : input;
-	if (authSources[url]) {
-		if (!options) { options = {}; }
-		if (!options.headers) { options.headers = {} }
-		if (!options.headers.authorization) { options.headers.authorization = 'Basic ' + Buffer.from(authSources[url]).toString('base64'); }
-	}
-	if (options && options.body) {
-	 	const query = (options.body.get)? options.body.get('query') : options.body;
-	 	// const controller = new AbortController(); -> disable timeouts
-		// options.signal = controller.signal;
-		return new Promise((resolve, reject) => {
-			let start = Date.now();
-			fetch(url, options).then(res => {
-				const diff = Math.round((Date.now() - start) / 1000 * 10) / 10, error = res.status != 200;
-				let m = (error)? res.status + ' error' : diff + 's';
-				if (error || diff > 1 || debug)
-					console.log('Forwarded to <' + input + '> (' + m + ')\n---\n' + query + '\n---');
-				resolve(res);
-			}).catch(err => {
-				console.log('Forwarded to <' + input + '> (error)\n---\n' + query + '\n---');
-				console.log(err);
-				reject(err);
-			});
-		});
-	}
-	else if (!input.endsWith('/sparql')) {
-		// advanced hacking to mediate between e.g. GraphDB not sticking to SPARQL end-point specs and Comunica expecting an end-point to end with /sparql
-		url = input + '/sparql';
-		redirects[url] = input;
-		// console.log(input, options);
-		return new Promise(resolve => {
-			// impersonate our own end-point for a non-compliant one
-			const me = 'http://localhost:' + config.get('otfc.port') + '/sparql';
-			fetch(me, options).then(res => {
-				// Comunica will use the response url to fire subsequent queries, hack it in
-				const key = Reflect.ownKeys(res).find(key => key.toString() === 'Symbol(state)');
-				res[key].urlList = [ new URL(url) ];
-				resolve(res);
-			});
-		});
-	}
-	return fetch(input, options);
 }
 
 async function meta() {
@@ -418,8 +289,58 @@ async function probe() {
 	return { subjects: subjects, predicates: predicates, objects: objects, subjectMappings: subjectMappings, objectMappings: objectMappings };
 }
 
+let _redirects = {};
+
+function otfcFetch(input, options) {
+	let url = _redirects[input]? _redirects[input] : input;
+	if (authSources[url]) {
+		if (!options) { options = {}; }
+		if (!options.headers) { options.headers = {} }
+		if (!options.headers.authorization) { options.headers.authorization = 'Basic ' + Buffer.from(authSources[url]).toString('base64'); }
+	}
+	if (options && options.body) {
+		const query = (options.body.get)? options.body.get('query') : options.body;
+		// const controller = new AbortController(); -> disable timeouts
+		// options.signal = controller.signal;
+		return new Promise((resolve, reject) => {
+			let start = Date.now();
+			fetch(url, options).then(res => {
+				const diff = Math.round((Date.now() - start) / 1000 * 10) / 10, error = res.status != 200;
+				let m = (error)? res.status + ' error' : diff + 's';
+				if (error || diff > 1 || debug)
+					console.log('Forwarded to <' + input + '> (' + m + ')\n---\n' + query + '\n---');
+				resolve(res);
+			}).catch(err => {
+				console.log('Forwarded to <' + input + '> (error)\n---\n' + query + '\n---');
+				console.log(err);
+				reject(err);
+			});
+		});
+	}
+	else if (!input.endsWith('/sparql')) {
+		// advanced hacking to mediate between e.g. GraphDB not sticking to SPARQL end-point specs and Comunica expecting an end-point to end with /sparql
+		url = input + '/sparql';
+		_redirects[url] = input;
+		// console.log(input, options);
+		return new Promise(resolve => {
+			// impersonate our own end-point for a non-compliant one
+			const me = 'http://localhost:' + config.get('otfc.port') + '/sparql';
+			fetch(me, options).then(res => {
+				// Comunica will use the response url to fire subsequent queries, hack it in
+				const key = Reflect.ownKeys(res).find(key => key.toString() === 'Symbol(state)');
+				res[key].urlList = [ new URL(url) ];
+				resolve(res);
+			});
+		});
+	}
+	return fetch(input, options);
+}
+
 await loadPredicates();
 await loadExtensionFunctions();
 
-const features = { virtualPredicates: Object.keys(predicatesToSubstitute).concat(Object.keys(predicatesToCompute)).sort(), extensionFunctions: extensionFunctions };
+const features = {
+	virtualPredicates: Object.keys(predicatesToSubstitute).concat(Object.keys(predicatesToCompute)).sort(),
+	extensionFunctions: extensionFunctions
+};
 export { QueryEngine, features };

--- a/src/predicate.js
+++ b/src/predicate.js
@@ -51,45 +51,6 @@ export default class Predicate {
 		return q0;
 	}
 
-	static submerge(q0 /* user query */, q1 /* substitute query */, predicate) {
-		let prefixes = q0.prefixes();
-		for (const p in q1.prefixes()) {
-			prefixes[p] = q1.prefixes()[p];
-		}
-		q0.setPrefixes(prefixes);
-		for (const t of q0.whereTriples()) {
-			if (t.predicate.value === predicate) {
-				q0.removeWhereTriples([ t ]);
-				for (const tt of q1.whereTriples()) {
-					const s = (tt.subject.value === '_s')? t.subject : tt.subject;
-					const o = (tt.object.value === '_o')? t.object : tt.object;
-					q0.addWhereTriples([ { subject: s, predicate: tt.predicate, object: o } ]);
-				}
-				const replaceVariablesInExpressions = (args) => {
-					for (let arg of args) {
-						if (isVariable(arg) && arg.value === '_s') arg.value = t.subject.value;
-						else if (isVariable(arg) && arg.value === '_s') arg.value = t.object.value;
-						if (arg.args) replaceVariablesInExpressions(arg.args);
-					}	
-				};
-				for (const bb of q1.whereBinds()) {
-					let b = { ...bb };
-					if (b.variable?.value === '_s') b.variable.value = t.subject.value;
-					else if (b.variable?.value === '_o') b.variable.value = t.object.value;
-					if (b.expression) {
-						replaceVariablesInExpressions(b.expression.args);
-					}
-					q0.addWhereBinds([ b ]);
-				}
-				for (const ff of q1.whereFilters()) {
-					replaceVariablesInExpressions(f.args);
-					q0.addWhereFilters([ f ]);
-				}				
-			}
-		}
-		return q0.toString();
-	}
-
 	static iri(n) {
 		return namedNode(n);
 	}

--- a/src/predicates/bondActor.js
+++ b/src/predicates/bondActor.js
@@ -1,0 +1,20 @@
+/* Copyright (C) 2022 Flanders Make - CodesignS */
+
+import Predicate from '../predicate.js';
+
+export default class BondActorPredicate extends Predicate {
+	static iri = 'http://flandersmake.be/otfc/bondActor';
+
+	static substitutionQuery = `
+		PREFIX dbo: <http://dbpedia.org/ontology/>
+		PREFIX dbr: <http://dbpedia.org/resource/>
+		PREFIX dbp: <http://dbpedia.org/property/>
+		PREFIX dbc: <http://dbpedia.org/resource/Category:>
+		SELECT *
+		WHERE {
+			?_s dbo:wikiPageWikiLink dbc:James_Bond_films.
+			?_s dbo:starring ?_o.
+			dbr:Portrayal_of_James_Bond_in_film dbo:portrayer ?_o.
+		}
+	`;
+}

--- a/src/substitutionHandler.js
+++ b/src/substitutionHandler.js
@@ -1,0 +1,524 @@
+/* Copyright (C) 2024 Flanders Make - CodesignS */
+
+import sparqljs from 'sparqljs';
+import * as Algebra from 'sparqlalgebrajs';
+import chalk from 'chalk';
+import { v4 as uuidv4 } from 'uuid';
+
+/**
+ * This class can perform substitution of predicates that occur in a userquery.
+ * It refuses to replace predicates that occur in complex path expressions.
+ * FIXME: It could be useful to relax this for pathReplacements (a predicate that can be replaced by just a path).
+ */
+export default class SubstitutionHandler {
+    // The SPARQL parser for internal use only.
+    _parser;
+    _doLog = false;
+
+    constructor() {
+        this._parser = new sparqljs.Parser();
+    }
+
+    /**
+     * Method performs all substitutions on the provided userQuery.
+     * @param {string} userQuery - The original user query in SPARQL
+     * @param {Object} predicatesToSubstitute - The Object containing predicates to substitute
+     * @returns {string} the original userQuery in SPARQL format, with all substitutions performed.
+     */
+    handle(userQuery, predicatesToSubstitute) {
+        // Convert the userQuery to algebraic form
+        const parsedUQ = this._parser.parse(userQuery);
+        const algebraUQ = Algebra.translate(parsedUQ);
+
+        // Walk over the algebra and perform substitutions
+        this._doSubstitute(algebraUQ, predicatesToSubstitute);
+
+        return Algebra.toSparql(algebraUQ);
+    }
+
+    /**
+     * Method intended to be called recursively in order to walk over the full algebraic structure of the query.
+     * This method modifies the provided algebra in place (so modifies the provided algebra).
+     * @param {Algebra} algebra - The algebra of the user query (being modified in place!)
+     * @param {Object} predicatesToSubstitute - The Object containing predicates to substitute
+     * @param {string} contextMsg - A context msg for clarifying errors.
+     * @returns {void}
+     */
+    _doSubstitute(algebra, predicatesToSubstitute, contextMsg) {
+        if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: Handling '${algebra.type}'`));
+        switch (algebra.type) {
+            case 'bgp':
+                {
+                    const convertedElement = this._handleBGP(algebra, predicatesToSubstitute)
+                    if (!convertedElement) {
+                        // No conversion was required. Keep as is.
+                    } else {
+                        // Replace the current algebra with the convertedElement
+                        // Pure assignment will not work (only local reference would change).
+                        // algebra = convertedElement;
+
+                        // Clear existing properties
+                        for (let key in algebra) {
+                            if (algebra.hasOwnProperty(key)) {
+                                delete algebra[key];
+                            }
+                        }
+
+                        // Assign new properties
+                        Object.assign(algebra, convertedElement);
+
+                        // Re-handle the algebra on the current level (it changed and might need additional replacements).
+                        this._doSubstitute(algebra, predicatesToSubstitute)
+                    }
+                };
+                break;
+            case 'join':
+                {
+                    // Joins need to be handled on this level.
+                    // They might carry bgp blocks that would result in an additional join level
+                    // while that element could easily be added to this join.
+
+                    // Does the join contain any members that are BGP's that require handling?
+                    let i = 0;
+                    while (i < algebra.input.length) {
+                        const currentElement = algebra.input[i];
+                        if (currentElement.type === 'bgp') {
+                            const convertedElement = this._handleBGP(currentElement, predicatesToSubstitute)
+                            if (!convertedElement) {
+                                // No conversion was required. Keep as is.
+                            } else if (convertedElement.type === 'join') {
+                                // Add this join's members to the current algebra.input, instead of the current element.
+                                algebra.input.splice(i, 1, ...convertedElement.input);
+
+                                // Keep the loop as of this element, since it may now be another BGP that requires replacement.
+                                i--;
+                            } else {
+                                // The convertedElement is another type of object.
+                                // Replace the current element with it.
+                                algebra.input.splice(i, 1, convertedElement);
+                                i--;
+                            }
+                        } else {
+                            // This is another kind of element, so handle it.
+                            this._doSubstitute(currentElement, predicatesToSubstitute);
+                        }
+
+                        // Go to the next element
+                        i++;
+                    }
+                };
+                break;
+            case 'leftjoin':
+                {
+                    // The leftjoin has to be handled by considering both sides independently.
+                    // It is not similar to a join, where any substitutions can be added to the main leftjoin.
+                    this._doSubstitute(algebra.input[0], predicatesToSubstitute);
+                    this._doSubstitute(algebra.input[1], predicatesToSubstitute);
+                }
+                break;
+            case 'filter':
+                {
+                    // Filters have an input and an expression.
+                    this._doSubstitute(algebra.input, predicatesToSubstitute);
+
+                    // The expression can be nested, handle it as a seperate algebraic element
+                    this._doSubstitute(algebra.expression, predicatesToSubstitute);
+                }
+                break;
+            case 'expression':
+                {
+                    if (algebra.expressionType === 'operator') {
+                        // An operator has arguments. Process all arguments
+                        for (let arg of algebra.args) {
+                            this._doSubstitute(arg, predicatesToSubstitute);
+                        }
+                    } else if (algebra.expressionType === 'existence') {
+                        // Substitutions can only happen in expressions of type 'existence'
+                        this._doSubstitute(algebra.input, predicatesToSubstitute);
+                    } else if (algebra.expressionType === 'term') {
+                        // Nothing required for terms
+                    } else {
+                        if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: Unsupported expression type '${algebra.expressionType}'`));
+                    }
+                }
+                break;
+            case 'path':
+                {
+                    // The fact that the algebra still contains a path, means that the path could not be expanded automatically.
+                    // Any occurrence of a substitution predicate in here is illegal.
+                    const predicate = algebra.predicate;
+                    const predicateType = predicate.type;
+                    if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: handling path type '${predicateType}'`));
+                    this._doSubstitute(predicate, predicatesToSubstitute, predicateType);
+                }
+                break;
+            case 'link':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: handling path type 'link'`));
+                    if (algebra.iri.value in predicatesToSubstitute) {
+                        throw Error(`Substitution of predicate ${algebra.iri.value} is not possible in path with '${contextMsg}'.`);
+                    }
+                }
+                break;
+            case 'inv':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: handling path type 'inv'`));
+                    this._doSubstitute(algebra.path, predicatesToSubstitute, 'inv ^');
+                }
+                break;
+            case 'alt':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: handling path type 'alt'`));
+                    let i = 0;
+                    while (i < algebra.input.length) {
+                        this._doSubstitute(algebra.input[i], predicatesToSubstitute, 'alt |');
+                        i++;
+                    }
+                }
+                break;
+            case 'seq':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: handling path type 'seq'`));
+                    let i = 0;
+                    while (i < algebra.input.length) {
+                        this._doSubstitute(algebra.input[i], predicatesToSubstitute, 'seq /');
+                        i++;
+                    }
+                }
+                break;
+            case 'ZeroOrMorePath':
+            case 'OneOrMorePath':
+            case 'ZeroOrOnePath':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: handling path type '${algebra.type}'`));
+                    this._doSubstitute(algebra.path, predicatesToSubstitute, algebra.type);
+                }
+                break;
+            default:
+                {
+                    // All other elements can be handled easily
+                    if (this._doLog) console.log(chalk.blue.bold(`_doSubstitute: default handling of '${algebra.type}'`));
+                    if (algebra.input) {
+                        this._doSubstitute(algebra.input, predicatesToSubstitute);
+                    } else {
+                        // No handling required at anymore
+                    }
+                }
+        }
+    }
+
+    /**
+     * Method accepts a BGP element. If one of its patterns needs substitution,
+     * it converts the BGP into a JOIN having two members:
+     *   - the remaining BGP patterns (if any)
+     *   - the substitutionQuery appropriately adjusted
+     * This method always only handles one replacement at a time!
+     * @param {Algebra} bgpElement - The algebraic representation of a BGP element
+     * @param {Object} predicatesToSubstitute - The Object containing predicates to substitute
+     * @returns {Algebra} A new replacement algebra or undefined if nothing has been changed.
+     */
+    _handleBGP(bgpElement, predicatesToSubstitute) {
+        let replacedPattern = {};
+        let i = 0;
+        while (i < bgpElement.patterns.length) {
+            const currentPattern = bgpElement.patterns[i];
+
+            // Does it need substitution?
+            if (currentPattern.predicate.value in predicatesToSubstitute) {
+                try {
+                    let substitutionQuery = predicatesToSubstitute[currentPattern.predicate.value];
+
+                    // Remove the current pattern from the bgpElement
+                    bgpElement.patterns.splice(i,1);
+
+                    // Then determine the substitution element
+
+                    // First resolve all potential prefixes in the query.
+                    const parsedSQ = this._parser.parse(substitutionQuery);
+                    const algebraSQ = Algebra.translate(parsedSQ);
+
+                    // Create a unique appendix for this replacement with a dash-less UUID.
+                    const appendix = "_" + uuidv4().replace(/-/g, '');
+
+                    // Subject and object in the user query might be NamedNodes instead of variables.
+                    // So make sure to replace the ?_s and ?_o not just by name, but by their full representation.
+                    let unique_algebraSQ = this._renameVariables(algebraSQ, appendix, currentPattern.subject, currentPattern.object);
+
+                    // Now determine the substitution approach
+                    // If the algebra is a projection without grouping or other features, drop the projection.
+                    if (unique_algebraSQ.input) {
+                        let next_input = unique_algebraSQ.input
+                        // For 'extend' look at the nested input for the first one that is not an 'extend'
+                        while (next_input.type == 'extend') {
+                            next_input = next_input.input
+                        }
+                        if (["orderby", "group", "slice"].includes(next_input.type)) {
+                            // The outer projection is required. Just keep it unmodified.
+                        } else {
+                            // The outer projection can be removed safely.
+                            unique_algebraSQ = unique_algebraSQ.input;
+                        }
+                    }
+
+                    const isolatedAlgebraSQ = unique_algebraSQ;
+
+                    // Is anything remaining on the bgp side?
+                    if (bgpElement.patterns.length>0) {
+                        if (isolatedAlgebraSQ.type==='bgp') {
+                            // Both BGPs can be joined.
+                            return {
+                                "type" : "bgp",
+                                "patterns": [
+                                    ...bgpElement.patterns , // All remaining patterns of the original BGP
+                                    ...isolatedAlgebraSQ.patterns  // The patterns of the substitution query
+                                ]
+                            }
+                        } else {
+                            // Return a join of both the bgp and the isolatedAlgebraSQ
+                            return {
+                                "type" : "join",
+                                "input": [
+                                    { ...bgpElement }, // A copy of the element, since it still is the original.
+                                    isolatedAlgebraSQ
+                                ]
+                            }
+                        }
+                    } else {
+                        // Only return the new isoletedAlgebraSQ
+                        return isolatedAlgebraSQ;
+                    }
+                } catch (error) {
+                    // FIXME: Why does this not print the nested stack?
+                    throw new Error(`Exception during substitution of predicate '${currentPattern.predicate.value}': 
+                        Nested exception: ${error.stack}
+                        ---
+                        `
+                    );
+                }
+            }
+
+            // Handle the next element
+            i++;
+        }
+
+        // If we come here, nothing changed, return undefined.
+        return undefined;
+    }
+
+    /**
+     * Method renames all variables in the provided algebra to unique names
+     * by appending the provided appendix.
+     * It changes the provided algebra in place and returns its value at the end.
+     * @param {Algebra} algebra - The algebra of the query to be modified.
+     * @param {string} appendix - The postfix to append to every variable.
+     * @param {string} subject_element - The element that replaces the ?_s (var or named node)
+     * @param {string} object_element - The element that replaces the ?_o (var or named node)
+     * @returns {Algebra} the modified algebra.
+     */
+    _renameVariables(algebra, appendix, subject_element, object_element) {
+        // The method cannot be directly called recursively, since it first needs to replace
+        // all internal variables and at the end handle the _s and _o.
+        // Performing all replacements at the same time may result in conflicts between
+        // the outer 'non-appended' variables that result from the binding and the original inner ones.
+        const renamerUnique = term => { 
+            const varName = term.value;
+            if (['_s','_o'].includes(varName)) {
+                // For now, don't change these
+            } else {
+                // Sometimes. the variable is referenced multiple times in the algebra.
+                // Avoid renaming the value twice.
+                // e.g. when ?a ?p ?o; ?p2 ?o2.
+                // The variable ?a then occurs twice, but is referencing the same JS object.
+                if (!varName.endsWith(appendix)) {
+                    term.value = varName + appendix;
+                }
+            }
+            return term
+        };
+        this._renameVariables_internal(algebra, renamerUnique);
+
+        const sIsVar = subject_element.type === 'variable';
+        const oIsVar = object_element.type === 'variable';
+
+        const renamerSpecial = term => {
+            const varName = term.value;
+            if ('_s' === varName) {
+                Object.assign(term, subject_element);
+            }
+            else if ('_o' === varName) {
+                Object.assign(term, object_element);
+            }
+            return term
+        };
+        this._renameVariables_internal(algebra, renamerSpecial);
+
+        return algebra;
+    }
+
+    /**
+     * Internal low level method for performing the actual renaming.
+     * Not to be called externally
+     * @param {Algebra} algebra - The algebra of the query to be modified.
+     * @param {lambda} renamer - The renamer to be called.
+     * @returns {void} 
+     */
+    _renameVariables_internal(algebra, renamer) {
+        // Directly replace variables
+        if (algebra.termType === 'Variable') {
+            if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: Variable '${algebra.value}'`));
+            renamer(algebra);
+        } else switch(algebra.type) {
+            case 'bgp':
+                {
+                    // Process patterns in a BGP
+                    algebra.patterns = algebra.patterns.map(pattern => {
+                        if (pattern.subject.termType === 'Variable') {
+                            if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: BGP subject ${pattern.subject.value}`));
+                            renamer(pattern.subject);
+                        }
+                        if (pattern.predicate.termType === 'Variable') {
+                            if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: BGP predicate ${pattern.predicate.value}`));
+                            renamer(pattern.predicate);
+                        }
+                        if (pattern.object.termType === 'Variable') {
+                            if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: BGP object ${pattern.object.value}`));
+                            renamer(pattern.object);
+                        }
+                        return pattern;
+                    });
+                }
+                break;
+            case 'project':
+            case 'group':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: '${algebra.type}'`));
+                    // Process other algebra types that contain variables
+                    algebra.variables = algebra.variables.map(variable => ({
+                        ...renamer(variable)
+                    }));
+                    // Only for group
+                    if (algebra.aggregates) {
+                        let i = 0;
+                        while (i < algebra.aggregates.length) {
+                            this._renameVariables_internal(algebra.aggregates[i], renamer);
+                            i++;
+                        }
+                    }
+                }
+                break;
+            case 'orderby':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: '${algebra.type}'`));
+                    if (algebra.expressions) {
+                        let i = 0;
+                        while (i < algebra.expressions.length) {
+                            this._renameVariables_internal(algebra.expressions[i], renamer);
+                            i++;
+                        }
+                    }
+                }
+                break;
+            case 'extend':
+            case 'bind':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: '${algebra.type}'`));
+                    // And the same, but different
+                    algebra.variable = {
+                        ...renamer(algebra.variable)
+                    };
+                    this._renameVariables_internal(algebra.expression, renamer);
+                }
+                break;
+            case 'values':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: '${algebra.type}'`));
+                    algebra.bindings = algebra.bindings.map(binding => {
+                        const newBinding = {};
+                        for (const key in binding) {
+                            const tmpVar = {
+                                type: 'variable',
+                                value: key
+                            }
+                            const newKey = renamer(tmpVar).value
+                            newBinding[newKey] = binding[key];
+                        }
+                        algebra.bindings = newBinding;
+                    });
+                }
+                break;
+            case 'path':
+                {
+                    if (algebra.subject.termType === 'Variable') {
+                        if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: path subject ${algebra.subject.value}`));
+                        renamer(algebra.subject);
+                    }
+                    // A path's predicate is not allowed to contain variables --> skip predicate
+                    if (algebra.object.termType === 'Variable') {
+                        if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: BGP object ${algebra.object.value}`));
+                        renamer(algebra.object);
+                    }
+                }
+                break;
+            case 'filter':
+                {
+                    // Next to an input, filters have an expression.
+                    // The expression can be nested, handle it as a seperate algebraic element
+                    if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: 'filter'`));
+                    this._renameVariables_internal(algebra.expression, renamer);
+                }
+                break;
+            case 'expression':
+                {
+                    if (algebra.expressionType === 'operator') {
+                        // An operator has arguments. Process all arguments
+                        if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: operator '${algebra.operator}'`));
+                        for (let arg of algebra.args) {
+                            this._renameVariables_internal(arg, renamer);
+                        }
+                    } else if (algebra.expressionType === 'existence') {
+                        this._renameVariables_internal(algebra.input, renamer);
+                    } else if (algebra.expressionType === 'term') {
+                        this._renameVariables_internal(algebra.term, renamer);
+                    } else if (algebra.expressionType === 'aggregate') {
+                        this._renameVariables_internal(algebra.expression, renamer);
+                        this._renameVariables_internal(algebra.variable, renamer);
+                    } else {
+                        if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: Unsupported expression type '${algebra.expressionType}'`));
+                    }
+                }
+                break;
+            case 'link':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: handling path type 'link' - skip`));
+                }
+                break;
+            case 'inv':
+                {
+                    if (this._doLog) console.log(chalk.blue.bold(`_renameVariables: handling path type 'inv'`));
+                    this._renameVariables_internal(algebra.path, renamer);
+                }
+                break;
+            case 'alt':
+            case 'seq':
+            case 'ZeroOrMorePath':
+            case 'OneOrMorePath':
+            case 'ZeroOrOnePath':
+            default:
+                // No action required (beyond possible algebra.input handled below)
+        }
+
+        // If the algebra also has an "input" member, then process all inputs.
+        if (algebra.input) {
+            if (Array.isArray(algebra.input)) {
+                let i = 0;
+                while (i < algebra.input.length) {
+                    this._renameVariables_internal(algebra.input[i], renamer);
+                    i++;
+                }
+            } else {
+                // If there is only one element, the input becomes an object instead
+                this._renameVariables_internal(algebra.input, renamer);
+            }
+        }
+    }
+}

--- a/src/tests/test_queries.js
+++ b/src/tests/test_queries.js
@@ -1,14 +1,14 @@
 /* Copyright (C) 2022 Flanders Make - CodesignS */
 
-import Query from './query.js';
-import { QueryEngine, features } from './engine.js';
-import Predicate from './predicate.js';
+import Query from '../query.js';
+import { QueryEngine, features } from '../engine.js';
+import Predicate from '../predicate.js';
 import fs from 'fs';
 
 const source = { type: 'sparql', value: 'https://dbpedia.org/sparql' };
 const engine = new QueryEngine();
 
-let query = fs.readFileSync('./queries/bond.sparql', 'utf8');
+let query = fs.readFileSync('../queries/bond.sparql', 'utf8');
 
 let i = 0;
 await engine.run(query, { source: source }, data => {

--- a/src/tests/test_substitution.js
+++ b/src/tests/test_substitution.js
@@ -1,0 +1,324 @@
+// Import required modules
+import sparqljs from 'sparqljs';
+import * as Algebra from 'sparqlalgebrajs';
+import SubstitutionHandler from '../substitutionHandler.js';
+import chalk from 'chalk';
+import  _  from 'lodash';
+
+const predicatesToSubstitute = [];
+predicatesToSubstitute["https://mydom2#predReplace"] = `
+    PREFIX : <https://mydom2#>
+    select ?_s ?_o where {
+        ?_s :predA ?a2.
+        optional {
+            ?a2 :predB ?c2.
+        }
+        {
+            select ?a2 ?_o {
+                ?a2 a :myClass;
+                    :predD ?_o.
+
+                ?a3 !(:predF|:predG)|:predH+|:predJ?|:predK*|(:predL|^:predM) ?_o.
+            }
+        }
+    }
+`;
+predicatesToSubstitute["https://mydom2#predReplace2"] = `
+  PREFIX : <https://mydom2#>
+  select (?a2 as ?_s) (?a3 as ?_o) (max(?a4) as ?b) where {
+    select * where {
+          ?a3 :predA ?a2.
+          OPTIONAL { ?s :predB ?a3. }
+          FILTER(
+            (
+              (
+                !(BOUND(?a3))
+              ) 
+              ||
+              (
+                EXISTS { 
+                  ?s :predC* ?a4.
+                }
+              )
+            ) 
+            &&
+            ( ?a5 <= ?a6 )
+          )
+      } order by (?a2 ) 
+  } group by ?a2 ?a3
+`;
+predicatesToSubstitute["https://mydom2#predReplace3"] = `
+  PREFIX : <https://mydom2#>
+  select ?_s ?_o where {
+    ?_s :testA ?_o.
+  } 
+`;
+
+const handler = new SubstitutionHandler();
+
+function testQ(q, expectedQ, msg) {
+    const resultQ = handler.handle(q, predicatesToSubstitute)
+
+    // Do not check for literal equivalence, but for algebraic equivalence.
+    const parser = new sparqljs.Parser();
+
+    // Parse to algebra and remove all replacement uuids
+    const expectedEQ = expectedQ.replace(/_[a-z0-9]{32,32}/g, '_replaced');
+    const parsedEQ = parser.parse(expectedEQ);
+    const algebraEQ = Algebra.translate(parsedEQ);
+    
+    const observedRQ = resultQ.replace(/_[a-z0-9]{32,32}/g, '_replaced');
+    const parsedRQ = parser.parse(observedRQ);
+    const algebraRQ= Algebra.translate(parsedRQ);
+
+    if (_.isEqual(algebraEQ,algebraRQ)) {
+        console.log(chalk.blue.bold(`Test '${msg}': Ok`));
+    } else {
+        console.log(chalk.red.bold(`Test '${msg}': Not equal`));
+        console.log(chalk.red.bold(`Test '${msg}': Expected \n${expectedEQ}\n`));
+        console.log(chalk.red.bold(`Test '${msg}': Observed \n${observedRQ}\n`));
+    }
+}
+
+function testQShouldFail(q, msg) {
+    try {
+        const resultQ = handler.handle(q, predicatesToSubstitute)
+
+        console.log(chalk.red.bold(`Test '${msg}': Does not produce expected exception.`));
+        try {
+            const parser = new sparqljs.Parser();
+
+            const observedRQ = resultQ.replace(/_[a-z0-9]{32,32}/g, '_replaced');
+            const parsedRQ = parser.parse(observedRQ);
+            const algebraRQ= Algebra.translate(parsedRQ);
+
+            console.log(chalk.red.bold(`Test '${msg}': Observed \n${observedRQ}`));
+        } catch (error) {
+            console.log(chalk.red.bold(`Test '${msg}': Observed result is not parseable... ${error}`));
+        }
+    } catch (error) {
+        console.log(chalk.blue.bold(`Test '${msg}': Ok. Received expected exception: ${error}`));
+    }
+}
+
+
+// Example SPARQL query
+const uq1 = `
+PREFIX : <https://mydom2#>
+  SELECT ?s ?p ?o
+  WHERE {
+	{
+		select ?a {
+			?a ?p ?o.
+		}
+	}
+	?a :predB ?b;
+	   :predC ?c;
+	   :predReplace/:predD* ?d. # Paths allowed
+	?d :predE ?e.
+	optional {
+		?a :predF ?f.
+	}
+	{
+		select ?f {
+			?f ?p2 ?o2.
+		}
+	}
+    ?a3 !(:predF|:predG)|:predH+|:predJ?|:predK*|(:predL|^:predM) ?b3.
+
+    FILTER ( # Filters supported
+      (?a > 3) 
+      || EXISTS {
+        ?q ^(:predReplace/:predN) ?q2. # Inverted path allowed, even with seq.
+      }
+    )
+  }
+`;
+
+const expected1 = `
+SELECT ?s ?p ?o WHERE {
+  { SELECT ?a WHERE { ?a ?p ?o. } }
+  ?a <https://mydom2#predB> ?b;
+    <https://mydom2#predC> ?c;
+    <https://mydom2#predA> ?a2_replaced.
+  OPTIONAL { ?a2_replaced <https://mydom2#predB> ?c2_replaced. }
+  {
+    SELECT ?a2_replaced ?var0 WHERE {
+      ?a2_replaced <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://mydom2#myClass>;
+        <https://mydom2#predD> ?var0.
+      ?a3_replaced (!(<https://mydom2#predF>|<https://mydom2#predG>)|(<https://mydom2#predH>+)|(<https://mydom2#predJ>?)|(<https://mydom2#predK>*)|<https://mydom2#predL>|^<https://mydom2#predM>) ?var0.
+    }
+  }
+  ?var0 (<https://mydom2#predD>*) ?d.
+  ?d <https://mydom2#predE> ?e.
+  OPTIONAL { ?a <https://mydom2#predF> ?f. }
+  { SELECT ?f WHERE { ?f ?p2 ?o2. } }
+  ?a3 (!(<https://mydom2#predF>|<https://mydom2#predG>)|(<https://mydom2#predH>+)|(<https://mydom2#predJ>?)|(<https://mydom2#predK>*)|<https://mydom2#predL>|^<https://mydom2#predM>) ?b3.
+  FILTER((?a > 3 ) || (EXISTS {
+    ?var0 <https://mydom2#predN> ?q.
+    ?q2 <https://mydom2#predA> ?a2_replaced.
+    OPTIONAL { ?a2_replaced <https://mydom2#predB> ?c2_replaced. }
+    {
+      SELECT ?a2_replaced ?var0 WHERE {
+        ?a2_replaced <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://mydom2#myClass>;
+          <https://mydom2#predD> ?var0.
+        ?a3_replaced (!(<https://mydom2#predF>|<https://mydom2#predG>)|(<https://mydom2#predH>+)|(<https://mydom2#predJ>?)|(<https://mydom2#predK>*)|<https://mydom2#predL>|^<https://mydom2#predM>) ?var0.
+      }
+    }
+  }))
+}`;
+
+const uq2 = `
+PREFIX : <https://mydom2#>
+  SELECT ?s ?p ?o
+  WHERE {
+    ?s :predA*/(^:predB|:predC)/:predReplace/(:predD/:predE)* ?o.
+  }
+`;
+
+const expected2 = `
+SELECT ?s ?p ?o WHERE {
+  ?s (<https://mydom2#predA>*) ?var0.
+  ?var0 (^<https://mydom2#predB>|<https://mydom2#predC>) ?var1.
+  ?var1 <https://mydom2#predA> ?a2_replaced.
+  OPTIONAL { ?a2_replaced <https://mydom2#predB> ?c2_replaced. }
+  {
+    SELECT ?a2_replaced ?var2 WHERE {
+      ?a2_replaced <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <https://mydom2#myClass>;
+        <https://mydom2#predD> ?var2.
+      ?a3_replaced (!(<https://mydom2#predF>|<https://mydom2#predG>)|(<https://mydom2#predH>+)|(<https://mydom2#predJ>?)|(<https://mydom2#predK>*)|<https://mydom2#predL>|^<https://mydom2#predM>) ?var2.
+    }
+  }
+  ?var2 ((<https://mydom2#predD>/<https://mydom2#predE>)*) ?o.
+}
+`;
+
+const uq3 = `
+PREFIX : <https://mydom2#>
+  SELECT ?s ?p ?o
+  WHERE {
+    ?s ?p ?o.
+    ?s :predReplace2 ?o2.
+  }
+`;
+
+const expected3 = `
+SELECT ?s ?p ?o WHERE {
+  ?s ?p ?o.
+  {
+    SELECT (?a2_replaced AS ?s) (?a3_replaced AS ?o2) (MAX(?a4_replaced) AS ?b_replaced) WHERE {
+      SELECT ?a2_replaced ?a3_replaced ?s_replaced WHERE {
+        ?a3_replaced <https://mydom2#predA> ?a2_replaced.
+        OPTIONAL { ?s_replaced <https://mydom2#predB> ?a3_replaced. }
+        FILTER(((!(BOUND(?a3_replaced))) || (EXISTS { ?s_replaced (<https://mydom2#predC>*) ?a4_replaced. })) && (?a5_replaced <= ?a6_replaced))
+      }
+      ORDER BY (?a2_replaced)
+    }
+    GROUP BY ?a2_replaced ?a3_replaced
+  }
+}
+`;
+
+const uq4 = `
+PREFIX : <https://mydom2#>
+  SELECT ?s ?p ?o
+  WHERE {
+    ?s ?p ?o;
+       :predReplace3 ?o2.
+  }
+`;
+
+
+const expected4 = `
+SELECT ?s ?p ?o WHERE {
+  ?s ?p ?o;
+    <https://mydom2#testA> ?o2.
+}
+`;
+
+const uq5 = `
+PREFIX : <https://mydom2#>
+  SELECT ?s ?p ?o
+  WHERE {
+    ?s ?p ?o;
+       :predReplace3 4.
+  }
+`;
+
+const expected5 = `
+SELECT ?s ?p ?o WHERE {
+  ?s ?p ?o;
+    <https://mydom2#testA> 4.
+}
+`;
+
+const uq6 = `
+PREFIX : <https://mydom2#>
+  SELECT ?s ?p ?o
+  WHERE {
+   <http://abc> ?p ?o;
+       :predReplace3 ?o2.
+  }
+`;
+
+const expected6 = `
+SELECT ?s ?p ?o WHERE {
+  <http://abc> ?p ?o;
+    <https://mydom2#testA> ?o2.
+}
+`;
+
+testQ(uq1, expected1, "ok1");
+testQ(uq2, expected2, "ok2");
+testQ(uq3, expected3, "ok3");
+testQ(uq4, expected4, "ok4 - simple 1/1 replacement of predicate");
+testQ(uq5, expected5, "ok5 - object is named node");
+testQ(uq6, expected6, "ok6 - subject is named node");
+
+testQShouldFail(`
+    PREFIX : <https://mydom2#>
+    SELECT ?s ?p ?o
+    WHERE {
+        ?s (:predB|^:predReplace) ?o.
+    }
+    `,"alt");
+
+testQShouldFail(`
+    PREFIX : <https://mydom2#>
+    SELECT ?s ?p ?o
+    WHERE {
+        ?s (^:predB|:predReplace) ?o.
+    }
+    `, "inv");
+
+testQShouldFail(`
+    PREFIX : <https://mydom2#>
+        SELECT ?s ?p ?o
+        WHERE {
+        ?s :predReplace* ?o.
+        }
+    `, "ZeroOrMore");
+    
+testQShouldFail(`
+    PREFIX : <https://mydom2#>
+        SELECT ?s ?p ?o
+        WHERE {
+        ?s :predReplace? ?o.
+        }
+    `, "ZeroOrOne");
+
+  testQShouldFail(`
+    PREFIX : <https://mydom2#>
+        SELECT ?s ?p ?o
+        WHERE {
+        ?s :predReplace+ ?o.
+        }
+    `, "OneOrMore");
+    
+  testQShouldFail(`
+    PREFIX : <https://mydom2#>
+        SELECT ?s ?p ?o
+        WHERE {
+        ?s :predA|(:predB/:predReplace) ?o.
+        }
+    `, "Sequence");

--- a/src/tests/test_substitutionSpecial.js
+++ b/src/tests/test_substitutionSpecial.js
@@ -1,0 +1,28 @@
+// Import required modules
+import sparqljs from 'sparqljs';
+import * as Algebra from 'sparqlalgebrajs';
+
+const expected1 = `
+SELECT ?s ?p ?o WHERE {
+  ?a <https://mydom2#predB> ?b.
+  FILTER EXISTS {
+    ?var0 <https://mydom2#predN> ?q. #### THIS line is kept.
+    { #### THIS block is removed
+      SELECT (?_s AS ?q2) (?_o AS ?var0) WHERE {
+        ?_s ?p ?_o.
+      }
+    }
+  }
+}`;
+
+const parser = new sparqljs.Parser();
+const parsed1 = parser.parse(expected1);
+const algebra1 = Algebra.translate(parsed1);
+const serial1 = Algebra.toSparql(algebra1);
+
+// Serial 1 seems to be:
+const observedSerial1 = `
+ SELECT ?s ?p ?o WHERE {
+  ?a <https://mydom2#predB> ?b.
+  FILTER(EXISTS { ?var0 <https://mydom2#predN> ?q. })
+}`;


### PR DESCRIPTION
Several improvements are included in this commit:
* The sparqlalgebrajs module is now used to be able to more intelligently substitute predicates while allowing more complex user queries.
* A Visual Studio Code dev container is created
* Some local testing is added

**Limitation:** 
The improvement is not active for computed predicates yet. Once a single computed predicate is defined, the system will fallback to the stricter approach and complex user queries will not be possible anymore. In order to try the improved substitution abilities, only substitution queries should be defined. The user will therefore need to remove the example bondActorAge.js computed predicate. The extension of the same approach towards the computed predicates is on our todo list.